### PR TITLE
fix: fixed max score being reset when current score is reset

### DIFF
--- a/src/state.cpp
+++ b/src/state.cpp
@@ -115,6 +115,5 @@ void StateManager::hit_ground(MissileModel* model) {
         m_state.m_score -= dec;
     else {
         m_state.m_score = 0;
-        m_state.m_max_score = 0;
     }
 }


### PR DESCRIPTION
Max score was being reset alongside current score when current score is smaller than the hit ground points decrement. This pull request removes this undesired behavior.