### PR TITLE
fix: removed wrong [[unlikely]] attribute from most likely case on ru…

### DIFF
--- a/src/assert.hpp
+++ b/src/assert.hpp
@@ -30,7 +30,7 @@ inline void rb_assert(bool result, std::string const& message = "") {
 }
 
 inline void rb_runtime_assert(bool result, std::string const& message = "") {
-    if (result == true) [[unlikely]]
+    if (result == true) [[likely]]
         return;
 
     std::string panic_message;


### PR DESCRIPTION
The most likely case on an assert is that is true and does nothing, so the [[unlikely]] attribute on the return statement on runtime_assert was misplaced.